### PR TITLE
portal deployment fixes

### DIFF
--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -18,6 +18,9 @@ ENV LOGNAME arcgis
 
 WORKDIR ${HOME}
 
+# The installer will not run as root.
+USER arcgis
+
 # Set path so we can run psql from bash shell
 # Note that it's listening on port 7654, so try
 # psql -h localhost -p 7654 -U siteadmin gwdb

--- a/portal/bashrc
+++ b/portal/bashrc
@@ -4,14 +4,14 @@ export PS1="Portal$ "
 # In Portal, each tool is in a separate folder in
 # tools/ -- bad idea.. whatever.. there are more tools
 # these are just the ones I added today.
-PATH=$PATH:${HOME}/portal:\
-${HOME}/portal/framework/etc:\
-${HOME}/portal/tools/accountmanagement:\
-${HOME}/portal/tools/createportal:\
-${HOME}/portal/tools/operationalhealth:\
-${HOME}/portal/tools/importlicense:\
-${HOME}/portal/tools/indexer:\
-${HOME}/portal/tools/portaldiag:\
-${HOME}/portal/tools/webgisdr
+PATH=$PATH:$HOME/portal:\
+$HOME/portal/framework/etc:\
+$HOME/portal/tools/accountmanagement:\
+$HOME/portal/tools/createportal:\
+$HOME/portal/tools/operationalhealth:\
+$HOME/portal/tools/importlicense:\
+$HOME/portal/tools/indexer:\
+$HOME/portal/tools/portaldiag:\
+$HOME/portal/tools/webgisdr
 
 export PATH

--- a/portal/start.sh
+++ b/portal/start.sh
@@ -23,7 +23,7 @@ if [ -f $SCRIPT ]; then
   echo "Portal for ArcGIS is already installed."
 else
   echo "Installing Portal"
-  /app/Installer/Setup -m silent --verbose -l yes
+  /app/Installer/Setup -m silent -d /home --verbose -l yes
 fi
 
 # Is it running already? 


### PR DESCRIPTION
Hey! Thank you so much for this repo, it's super handy!

I had to make the following changes to install Portal properly:
1) I've added "-d /home" param to the Setup script, because the script automatically appends "/arcgis/portal" path to the installation directory. Because of that the program then ended up in /home/arcgis/arcgis/portal
2) Added USER entry in the Dockerfile, as it wouldn't install otherwise;
3) Changed ${HOME} to $HOME in the bashrc file.